### PR TITLE
Correct comment syntax in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,13 +1,13 @@
-//
-//    FILE:  keywords.txt
-//  AUTHOR:  Jimmy Patrick
-// VERSION:  0.0.10
-// PURPOSE:  Controls a Parallel Printer through a PFC8574
-//    DATE:  2013-12-18
-//     URL:
-//
-// Released to the public domain. Thanks to Rob Tillaart for helping me get this started. 
-//
+#
+#    FILE:  keywords.txt
+#  AUTHOR:  Jimmy Patrick
+# VERSION:  0.0.10
+# PURPOSE:  Controls a Parallel Printer through a PFC8574
+#    DATE:  2013-12-18
+#     URL:
+#
+# Released to the public domain. Thanks to Rob Tillaart for helping me get this started. 
+#
 
 Thermal_Printer_I2C	KEYWORD1
 #


### PR DESCRIPTION
keywords.txt uses # for comments.